### PR TITLE
Safe index creation

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -33,7 +33,7 @@ module Database.Orville.Core
   , ColumnType (..)
   , FieldDefinition, withPrefix, fieldName
   , IndexDefinition (..)
-  , uniqueIndex, simpleIndex
+  , IndexName, uniqueIndex, simpleIndex, indexNameToString, stringToIndexName, safeStringToIndexName
 
   , ConstraintDefinition (..)
   , uniqueConstraint, dropConstraint

--- a/src/Database/Orville/Internal/IndexDefinition.hs
+++ b/src/Database/Orville/Internal/IndexDefinition.hs
@@ -42,10 +42,7 @@ indexNameToString :: IndexName -> String
 indexNameToString (IndexName i) = i
 
 stringToIndexName :: String -> IndexName
-stringToIndexName name =
-  case safeStringToIndexName name of
-    Left err -> error err
-    Right iName -> iName
+stringToIndexName = either error id . safeStringToIndexName
 
 safeStringToIndexName :: String -> Either String IndexName
 safeStringToIndexName name =

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- HDBC-postgresql-2.3.2.6
+- HDBC-postgresql-2.3.2.7
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: HDBC-postgresql-2.3.2.6@sha256:6e1636b0414ae7b028a01f1a90cf3e28c14f1df7867cf2615d5357d9abcd6279,3164
+    hackage: HDBC-postgresql-2.3.2.7@sha256:93d8e3c3d2dc9291a10f28ae3f8d0604a55ef47298ed43003a4d16f3d9905bae,3228
     pantry-tree:
       size: 1740
-      sha256: 447f1893e85d46f3f1c5e8b43ed46e4ff9563223c2ae0b6b78de624a9f0563c1
+      sha256: 07bfba988402849f447025b324f2993ea88ac0ec4f7dd4b86942644e2e239d45
   original:
-    hackage: HDBC-postgresql-2.3.2.6
+    hackage: HDBC-postgresql-2.3.2.7
 snapshots:
 - completed:
     size: 524127


### PR DESCRIPTION
Postgresql only allows 63 character index names. Since we only intend to use Orville with postgres with default values we can just hardcode the assumption that index names cannot be longer than 63 characters.